### PR TITLE
add minimum supported nodejs version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "start": "node server/index.js"
   },
+  "engines" : { 
+    "node" : ">=14.0.0"
+  },
   "dependencies": {
     "adm-zip": "^0.5.10",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
theres some syntax that isn't supported on old versions of node. I ran into it when messing with this on a VM with an old node version, so I figured we could make the error slightly more obvious.